### PR TITLE
Remove jsonlite::toJSON/fromJSON and JSON.parse/stringify

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -32,7 +32,7 @@ toR = function(data, changes, params, ...) {
   colHeaders = unlist(params$colHeaders)
   rowHeaders = unlist(params$rowHeaders)
 
-  out = jsonlite::fromJSON(data)
+  out = data
 
   # pre-conversion updates
   if (changes$event == "afterCreateRow") {

--- a/R/misc.R
+++ b/R/misc.R
@@ -62,6 +62,7 @@ toR = function(data, changes, params, ...) {
   if ("matrix" %in% rClass) {
     class(out) = params$rColClasses
   } else if ("data.frame" %in% rClass) {
+    out = matrix(unlist(out), nrow = length(out), byrow = TRUE)
     out = colClasses(as.data.frame(out, stringsAsFactors = FALSE),
                      rColClasses)
   } else {

--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -45,14 +45,14 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
         data[, i] = as.character(data[, i], format = DATE_FORMAT)
     }
 
-    cols = jsonlite::toJSON(data.frame(do.call(cbind, cols)))
+    cols = unclass(jsonlite::toJSON(data.frame(do.call(cbind, cols))))
   }
 
   # removes _row from jsonlite::toJSON
   rownames(data) = NULL
 
   x = list(
-    data = jsonlite::toJSON(data, na = "string"),
+    data = unclass(jsonlite::toJSON(data, na = "string")),
     rClass = rClass,
     rColClasses = rColClasses,
     colHeaders = colHeaders,
@@ -154,7 +154,7 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
                    readOnly = NULL, validator = NULL, allowInvalid = NULL,
                    halign = NULL, valign = NULL,
                    renderer = NULL) {
-  cols = jsonlite::fromJSON(hot$x$columns, simplifyVector = FALSE)
+  cols = unclass(jsonlite::fromJSON(hot$x$columns, simplifyVector = FALSE))
 
   if (is.character(col)) col = which(hot$x$colHeaders == col)
 
@@ -173,8 +173,8 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
     cols[[col]]$className = className
   }
 
-  hot$x$columns = jsonlite::toJSON(cols, auto_unbox = TRUE,
-                                   force = TRUE)
+  hot$x$columns = unclass(jsonlite::toJSON(cols, auto_unbox = TRUE,
+                                           force = TRUE))
   hot
 }
 
@@ -293,8 +293,8 @@ hot_rows = function(hot, rowHeights = NULL, fixedRowsTop = NULL) {
 hot_cell = function(hot, row, col, comment = NULL) {
   cell = list(row = row, col = col, comment = comment)
 
-  hot$x$cell = jsonlite::toJSON(c(hot$x$cell, list(cell)),
-                                auto_unbox = TRUE)
+  hot$x$cell = unclass(jsonlite::toJSON(c(hot$x$cell, list(cell)),
+                                        auto_unbox = TRUE))
 
   if (is.null(hot$x$comments))
     hot = hot %>% hot_table(comments = TRUE, contextMenu = TRUE)

--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -35,8 +35,6 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
   if(useTypes) {
     # get column data types
     col_typs = get_col_types(data)
-    cols = list(type = col_typs)
-    cols$readOnly = readOnly
 
     # format date for display
     dt_inds = which(col_typs == "date")
@@ -45,7 +43,11 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
         data[, i] = as.character(data[, i], format = DATE_FORMAT)
     }
 
-    cols = jsonlite::toJSON(data.frame(do.call(cbind, cols)))
+    cols = lapply(col_typs, function(type) {
+      res = list(type = type)
+      res$readOnly = readOnly
+      res
+    })
   }
 
   x = list(
@@ -151,7 +153,7 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
                    readOnly = NULL, validator = NULL, allowInvalid = NULL,
                    halign = NULL, valign = NULL,
                    renderer = NULL) {
-  cols = jsonlite::fromJSON(hot$x$columns, simplifyVector = FALSE)
+  cols = hot$x$columns
 
   if (is.character(col)) col = which(hot$x$colHeaders == col)
 
@@ -170,8 +172,7 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
     cols[[col]]$className = className
   }
 
-  hot$x$columns = jsonlite::toJSON(cols, auto_unbox = TRUE,
-                                   force = TRUE)
+  hot$x$columns = cols
   hot
 }
 
@@ -290,8 +291,7 @@ hot_rows = function(hot, rowHeights = NULL, fixedRowsTop = NULL) {
 hot_cell = function(hot, row, col, comment = NULL) {
   cell = list(row = row, col = col, comment = comment)
 
-  hot$x$cell = jsonlite::toJSON(c(hot$x$cell, list(cell)),
-                                auto_unbox = TRUE)
+  hot$x$cell = c(hot$x$cell, list(cell))
 
   if (is.null(hot$x$comments))
     hot = hot %>% hot_table(comments = TRUE, contextMenu = TRUE)

--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -48,11 +48,8 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
     cols = jsonlite::toJSON(data.frame(do.call(cbind, cols)))
   }
 
-  # removes _row from jsonlite::toJSON
-  rownames(data) = NULL
-
   x = list(
-    data = jsonlite::toJSON(data, na = "string"),
+    data = jsonlite::toJSON(data, na = "string", rownames = FALSE),
     rClass = rClass,
     rColClasses = rColClasses,
     colHeaders = colHeaders,

--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -29,7 +29,7 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
   if ("matrix" %in% rClass) {
     rColClasses = class(data[1, 1])
   } else {
-    rColClasses = sapply(data, class)
+    rColClasses = lapply(data, class)
   }
 
   if(useTypes) {

--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -45,14 +45,14 @@ rhandsontable <- function(data, colHeaders, rowHeaders, useTypes = TRUE,
         data[, i] = as.character(data[, i], format = DATE_FORMAT)
     }
 
-    cols = unclass(jsonlite::toJSON(data.frame(do.call(cbind, cols))))
+    cols = jsonlite::toJSON(data.frame(do.call(cbind, cols)))
   }
 
   # removes _row from jsonlite::toJSON
   rownames(data) = NULL
 
   x = list(
-    data = unclass(jsonlite::toJSON(data, na = "string")),
+    data = jsonlite::toJSON(data, na = "string"),
     rClass = rClass,
     rColClasses = rColClasses,
     colHeaders = colHeaders,
@@ -154,7 +154,7 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
                    readOnly = NULL, validator = NULL, allowInvalid = NULL,
                    halign = NULL, valign = NULL,
                    renderer = NULL) {
-  cols = unclass(jsonlite::fromJSON(hot$x$columns, simplifyVector = FALSE))
+  cols = jsonlite::fromJSON(hot$x$columns, simplifyVector = FALSE)
 
   if (is.character(col)) col = which(hot$x$colHeaders == col)
 
@@ -173,8 +173,8 @@ hot_col = function(hot, col, type = NULL, format = NULL, source = NULL,
     cols[[col]]$className = className
   }
 
-  hot$x$columns = unclass(jsonlite::toJSON(cols, auto_unbox = TRUE,
-                                           force = TRUE))
+  hot$x$columns = jsonlite::toJSON(cols, auto_unbox = TRUE,
+                                   force = TRUE)
   hot
 }
 
@@ -293,8 +293,8 @@ hot_rows = function(hot, rowHeights = NULL, fixedRowsTop = NULL) {
 hot_cell = function(hot, row, col, comment = NULL) {
   cell = list(row = row, col = col, comment = comment)
 
-  hot$x$cell = unclass(jsonlite::toJSON(c(hot$x$cell, list(cell)),
-                                        auto_unbox = TRUE))
+  hot$x$cell = jsonlite::toJSON(c(hot$x$cell, list(cell)),
+                                auto_unbox = TRUE)
 
   if (is.null(hot$x$comments))
     hot = hot %>% hot_table(comments = TRUE, contextMenu = TRUE)

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -38,18 +38,18 @@ rhandsontable(MAT, width = 300, height = 150) %>%
 
 # group rows and columns
 rhandsontable(MAT) %>%
-  hot_table(groups = jsonlite::toJSON(list(list(cols = c(0, 1)),
-                                           list(rows = c(0, 1)))))
+  hot_table(groups = list(list(cols = c(0, 1)),
+                          list(rows = c(0, 1))))
 
 # add custom borders
 rhandsontable(MAT) %>%
-  hot_table(customBorders = jsonlite::toJSON(list(list(
+  hot_table(customBorders = list(list(
     range = list(from = list(row = 1, col = 1),
                  to = list(row = 2, col = 2)),
     top = list(width = 2, color = "red"),
     left = list(width = 2, color = "red"),
     bottom = list(width = 2, color = "red"),
-    right = list(width = 2, color = "red"))), auto_unbox = TRUE))
+    right = list(width = 2, color = "red"))))
 
 # add numeric validation
 rhandsontable(MAT * 10) %>%

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -64,7 +64,7 @@ rhandsontable(DF) %>%
 
 # custom validation; try to update any cell to 0
 rhandsontable(MAT * 10) %>%
-  hot_cols(validator = gsub("\n", "", "
+  hot_cols(validator = "
     function (value, callback) {
       setTimeout(function(){
         if (value != 0) {
@@ -74,7 +74,7 @@ rhandsontable(MAT * 10) %>%
           callback(false);
         }
       }, 1000)
-    }"),
+    }",
            allowInvalid = FALSE)
 
 # add conditional formatting to a triangular matrix
@@ -83,7 +83,7 @@ MAT = matrix(runif(100, -1, 1), nrow = 10,
 diag(MAT) = 1
 MAT[upper.tri(MAT)] = MAT[lower.tri(MAT)]
 rhandsontable(MAT, readOnly = TRUE) %>%
-  hot_cols(renderer = gsub("\n", "", "
+  hot_cols(renderer = "
     function (instance, td, row, col, prop, value, cellProperties) {
       Handsontable.renderers.TextRenderer.apply(this, arguments);
       if (row == col) {
@@ -96,4 +96,4 @@ rhandsontable(MAT, readOnly = TRUE) %>%
       } else if (value > 0.75) {
         td.style.background = 'lightgreen';
       }
-    }"))
+    }")

--- a/inst/examples/examples.R
+++ b/inst/examples/examples.R
@@ -67,12 +67,7 @@ rhandsontable(MAT * 10) %>%
   hot_cols(validator = "
     function (value, callback) {
       setTimeout(function(){
-        if (value != 0) {
-          callback(true);
-        }
-        else {
-          callback(false);
-        }
+        callback(value != 0);
       }, 1000)
     }",
            allowInvalid = FALSE)

--- a/inst/examples/shiny_corr.R
+++ b/inst/examples/shiny_corr.R
@@ -45,7 +45,7 @@ server = function(input, output) {
     diag(MAT) = 1
     MAT[upper.tri(MAT)] = MAT[lower.tri(MAT)]
     rhandsontable(MAT, readOnly = TRUE) %>%
-      hot_cols(renderer = gsub("\n", "", "
+      hot_cols(renderer = "
                                function (instance, td, row, col, prop, value, cellProperties) {
                                 Handsontable.renderers.TextRenderer.apply(this, arguments);
                                 if (row == col) {
@@ -58,7 +58,7 @@ server = function(input, output) {
                                 } else if (value > 0.75) {
                                   td.style.background = 'lightgreen';
                                 }
-                               }"))
+                               }")
   })
 
   output$plot = renderMetricsgraphics({

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -18,21 +18,7 @@ HTMLWidgets.widget({
     hotParams[el.id] = x;
 
     // convert json to array
-    x.data = toArray(JSON.parse(x.data));
-
-    x.columns = JSON.parse(x.columns)
-
-    if (x.cell) {
-      x.cell = JSON.parse(x.cell)
-    }
-
-    if (x.customBorders) {
-      x.customBorders = JSON.parse(x.customBorders)
-    }
-
-    if (x.groups) {
-      x.groups = JSON.parse(x.groups)
-    }
+    x.data = toArray(x.data);
 
     x.afterLoadData = this.updateHeatmap;
     x.beforeChangeRender = this.updateHeatmap;
@@ -66,7 +52,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode && changes) {
         Shiny.onInputChange(this.rootElement.id, {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           changes: { event: "afterChange", changes: changes },
           params: hotParams[this.rootElement.id]
         });
@@ -81,7 +67,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode) {
         Shiny.onInputChange(this.rootElement.id + "_select", {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           select: { r: r, c: c, r2: r2, c2: c2},
           params: hotParams[this.rootElement.id]
         });
@@ -96,7 +82,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode)
         Shiny.onInputChange(this.rootElement.id, {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           changes: { event: "afterCreateRow", ind: ind, ct: ct },
           params: hotParams[this.rootElement.id]
         });
@@ -106,7 +92,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode)
         Shiny.onInputChange(this.rootElement.id, {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           changes: { event: "afterRemoveRow", ind: ind, ct: ct },
           params: hotParams[this.rootElement.id]
         });
@@ -116,7 +102,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode)
         Shiny.onInputChange(this.rootElement.id, {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           changes: { event: "afterCreateCol", ind: ind, ct: ct },
           params: hotParams[this.rootElement.id]
         });
@@ -126,7 +112,7 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode)
         Shiny.onInputChange(this.rootElement.id, {
-          data: JSON.stringify(this.getData()),
+          data: this.getData(),
           changes: { event: "afterRemoveCol", ind: ind, ct: ct },
           params: hotParams[this.rootElement.id]
         });

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -34,17 +34,6 @@ HTMLWidgets.widget({
       x.groups = JSON.parse(x.groups)
     }
 
-    for (var c in x.columns) {
-      col = x.columns[c];
-      if (col.renderer) {
-        x.columns[c].renderer = col.renderer.parseFunction()
-      }
-
-      if (col.validator) {
-        x.columns[c].validator = col.validator.parseFunction()
-      }
-    }
-
     x.afterLoadData = this.updateHeatmap;
     x.beforeChangeRender = this.updateHeatmap;
 
@@ -187,18 +176,3 @@ function toArray(obj) {
   }
   return result;
 }
-
-// http://stackoverflow.com/questions/1271516/executing-anonymous-functions-created-using-javascript-eval
-if (typeof String.prototype.parseFunction != 'function') {
-    String.prototype.parseFunction = function () {
-        var funcReg = /function *\(([^()]*)\)[ \n\t]*{(.*)}/gmi;
-        var match = funcReg.exec(this.replace(/\n/g, ' '));
-
-        if(match) {
-            return new Function(match[1].split(','), match[2]);
-        }
-
-        return null;
-    };
-}
-


### PR DESCRIPTION
With what we did in https://github.com/ramnathv/htmlwidgets/pull/28, you can get rid of a lot of R and JS code. If you find yourself have to worry about JSON when developing an HTML widget, that is probably the design flaw of the **htmlwidgets** package: as a widget author, you should only care about R data objects and JS data objects, and not worry about the intermediate media, i.e. JSON.

I have tested all your examples and fixed all issues I discovered. Due to a tiny problem that I overlooked in the metricsgraphics package (https://github.com/hrbrmstr/metricsgraphics/pull/22), you will have to install the latest development version when you test your examples that use metricsgraphics:

```r
devtools::install_github("hrbrmstr/metricsgraphics")
devtools::install_github(c('jeroenooms/jsonlite', 'rstudio/shiny', 'yihui/htmlwidgets@jsonlite'))
```

Please let me know if you have any questions.