### PR TITLE
Modify afterChange to work with column sort

### DIFF
--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -35,7 +35,7 @@ rhandsontable <- function(data, colHeaders, rowHeaders, comments = NULL,
                           useTypes = TRUE, readOnly = NULL,
                           selectCallback = FALSE,
                           width = NULL, height = NULL, digits = 4,
-                          debug = NULL, ...) {
+                          debug = NULL, persistentState = TRUE, ...) {
   rColHeaders = colnames(data)
   if (.row_names_info(data) > 0L)
     rRowHeaders = rownames(data)
@@ -119,6 +119,7 @@ rhandsontable <- function(data, colHeaders, rowHeaders, comments = NULL,
     rRowHeaders = rRowHeaders,
     rDataDim = dim(data),
     selectCallback = selectCallback,
+    persistentState = persistentState,
     colHeaders = colHeaders,
     rowHeaders = rowHeaders,
     columns = cols,

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -114,10 +114,9 @@ HTMLWidgets.widget({
             console.log("First condition met.");
             c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
             console.log("Brent Bugtesting - c at point 1: " + c);
-            d = [this.sortIndex[changes[0][0]][0]];
-            d = d.concat(changes[0].slice(1, 1 + 3));
-            c = [c, d];
-            console.log("Brent Bugtesting - c: " + c);
+            c = [this.sortIndex[changes[0][0]][0]];
+            c = c.concat(changes[0].slice(1, 1 + 3));
+            console.log("Brent Bugtesting - c at point 2: " + c);
             console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
             console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
             console.log("Brent Bugtesting - type of c: " + typeof(c));

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -109,17 +109,23 @@ HTMLWidgets.widget({
       }
 
       if (HTMLWidgets.shinyMode) {
-        if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
+        if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
-            c = [this.sortIndex[changes[0][0]][0]];
+            console.log("First condition met.");
+            c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+            console.log("Brent Bugtesting - c at point 1: " + c);
+            d = [this.sortIndex[changes[0][0]][0]];
+            d = d.concat(changes[0].slice(1, 1 + 3));
+            c = [c, d];
             console.log("Brent Bugtesting - c: " + c);
             console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
             console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
             console.log("Brent Bugtesting - type of c: " + typeof(c));
-            c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
+            console.log("Second condition met.");
             c = changes;
           }
+        
           
           if (this.params && this.params.debug) {
             if (this.params.debug > 0) {

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -111,16 +111,7 @@ HTMLWidgets.widget({
       if (HTMLWidgets.shinyMode) {
         if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
           if (changes.length > 1){
-            for (i = 0; i < changes.length; i++){
-              if(c){
-                c[i] = [this.sortIndex[changes[i][0]][0]];
-                c[i] = c[i].concat(changes[i].slice(1, 1 + 3));
-              } else {
-                c = new Array ( );
-                c[i] = [this.sortIndex[changes[i][0]][0]];
-                c[i] = c[i].concat(changes[i].slice(1, 1 + 3));
-              }
-            }
+            c = changes
           } else {
             if (this.sortIndex && this.sortIndex.length !== 0) {
               console.log("First condition met.");

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -112,10 +112,10 @@ HTMLWidgets.widget({
         if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
             c = [this.sortIndex[changes[0][0]][0]];
-            console.log("c: " + c);
-            console.log("sortIndex[changes]: " + this.sortIndex[changes]);
-            console.log("this.sortIndex: " + this.sortIndex);
-            console.log("type of c: " + typeof(c));
+            console.log("Brent Bugtesting - c: " + c);
+            console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
+            console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
+            console.log("Brent Bugtesting - type of c: " + typeof(c));
             c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
             c = changes;

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -128,17 +128,17 @@ HTMLWidgets.widget({
             if (this.sortIndex && this.sortIndex.length !== 0) {
               console.log("First condition met.");
               console.log("changes length: " + changes.length);
-              c[1] = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+              c[0] = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
               console.log("Brent Bugtesting - c at point 1: " + c);
-              c[1] = [this.sortIndex[changes[0][0]][0]];
-              c[1] = c[1].concat(changes[0].slice(1, 1 + 3));
+              c[0] = [this.sortIndex[changes[0][0]][0]];
+              c[0] = c[1].concat(changes[0].slice(1, 1 + 3));
               console.log("Brent Bugtesting - c at point 2: " + c);
               console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
               console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
               console.log("Brent Bugtesting - type of c: " + typeof(c));
             } else {
               console.log("Second condition met.");
-              c[1] = changes;
+              c[0] = changes;
             }
           }
         

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -114,6 +114,7 @@ HTMLWidgets.widget({
             c = this.sortIndex[changes[0][0]][0];
             console.log(c);
             console.log(this.sortIndex[changes]);
+            console.log(this.sortIndex);
             c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
             c = changes;

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -110,10 +110,14 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode) {
         if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
+          c = new Array ();
           if (changes.length > 1){
             if (this.sortIndex && this.sortIndex.length !== 0) {
-              c = new Array ();
               for(i=0;i<changes.length;i++){
+                console.log("sortIndex navtest1: " + this.sortIndex[i]);
+                console.log("sortIndex navtest2: " + this.sortIndex[i][0]);
+                console.log("sortIndex navtest3: " + [this.sortIndex[i][0]][0]);
+                console.log("sortIndex navtest4: " + [this.sortIndex[i][0]][1]);
                 c[i] = [this.sortIndex[changes[i][0]][0]];
                 c[i] = c[i].concat(changes[i].slice(1, 1+3));
               }
@@ -124,17 +128,17 @@ HTMLWidgets.widget({
             if (this.sortIndex && this.sortIndex.length !== 0) {
               console.log("First condition met.");
               console.log("changes length: " + changes.length);
-              c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+              c[1] = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
               console.log("Brent Bugtesting - c at point 1: " + c);
-              c = [this.sortIndex[changes[0][0]][0]];
-              c = c.concat(changes[0].slice(1, 1 + 3));
+              c[1] = [this.sortIndex[changes[0][0]][0]];
+              c[1] = c[1].concat(changes[0].slice(1, 1 + 3));
               console.log("Brent Bugtesting - c at point 2: " + c);
               console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
               console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
               console.log("Brent Bugtesting - type of c: " + typeof(c));
             } else {
               console.log("Second condition met.");
-              c = changes;
+              c[1] = changes;
             }
           }
         

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -109,13 +109,14 @@ HTMLWidgets.widget({
       }
 
       if (HTMLWidgets.shinyMode) {
-        if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
+        if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
-            c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+            c = this.sortIndex[changes[0][0]][0];
+            c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
             c = changes;
           }
-
+          
           if (this.params && this.params.debug) {
             if (this.params.debug > 0) {
               console.log("afterChange: Shiny.onInputChange: " + this.rootElement.id);

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -109,8 +109,9 @@ HTMLWidgets.widget({
       }
 
       if (HTMLWidgets.shinyMode) {
-        if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
+        if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] != changes[0][3])) {
           c = new Array ();
+          console.log("Length of changes: " + changes.length);
           if (changes.length > 1){
             if (this.sortIndex && this.sortIndex.length !== 0) {
               for(i=0;i<changes.length;i++){
@@ -118,8 +119,7 @@ HTMLWidgets.widget({
                 console.log("sortIndex navtest2: " + this.sortIndex[i][0]);
                 console.log("sortIndex navtest3: " + [this.sortIndex[i][0]][0]);
                 console.log("sortIndex navtest4: " + [this.sortIndex[i][0]][1]);
-                c[i] = [this.sortIndex[changes[i][0]][0]];
-                c[i] = c[i].concat(changes[i].slice(1, 1+3));
+                c[i] = [this.sortIndex[changes[i][0]][0], changes[i][1], changes[i][2], changes[i][3]];
               }
             } else {
               c = changes
@@ -128,10 +128,11 @@ HTMLWidgets.widget({
             if (this.sortIndex && this.sortIndex.length !== 0) {
               console.log("First condition met.");
               console.log("changes length: " + changes.length);
-              c[0] = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
-              console.log("Brent Bugtesting - c at point 1: " + c);
-              c[0] = [this.sortIndex[changes[0][0]][0]];
-              c[0] = c[1].concat(changes[0].slice(1, 1 + 3));
+              //c[0] = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+              //console.log("Brent Bugtesting - c at point 1: " + c);
+              //c[0] = [this.sortIndex[changes[0][0]][0]];
+              //c[0] = c[1].concat(changes[0].slice(1, 1 + 3));
+              c[0] = [this.sortIndex[changes[0][0]][0], changes[0][1], changes[0][2], changes[0][3]];
               console.log("Brent Bugtesting - c at point 2: " + c);
               console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
               console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -112,12 +112,13 @@ HTMLWidgets.widget({
         if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
             c = this.sortIndex[changes[0][0]][0];
-            console.log(c);
-            console.log(this.sortIndex[changes]);
-            console.log(this.sortIndex);
-            c = c.concat(changes[0].slice(1, 1 + 3));
+            console.log("c: " + c);
+            console.log("sortIndex[changes]: " + this.sortIndex[changes]);
+            console.log("this.sortIndex: " + this.sortIndex);
+            console.log("type of c: " + typeof(c));
+            //c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
-            c = changes;
+            //c = changes;
           }
           
           if (this.params && this.params.debug) {

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -112,7 +112,8 @@ HTMLWidgets.widget({
         if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
             c = this.sortIndex[changes[0][0]][0];
-            c = c.concat(changes[0].slice(1, 1 + 3));
+            console.log(c)
+            c = [c].concat(changes[0].slice(1, 1 + 3));
           } else {
             c = changes;
           }

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -112,6 +112,7 @@ HTMLWidgets.widget({
         if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
             console.log("First condition met.");
+            console.log("changes length: " + changes.length);
             c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
             console.log("Brent Bugtesting - c at point 1: " + c);
             c = [this.sortIndex[changes[0][0]][0]];

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -110,20 +110,33 @@ HTMLWidgets.widget({
 
       if (HTMLWidgets.shinyMode) {
         if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
-          if (this.sortIndex && this.sortIndex.length !== 0) {
-            console.log("First condition met.");
-            console.log("changes length: " + changes.length);
-            c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
-            console.log("Brent Bugtesting - c at point 1: " + c);
-            c = [this.sortIndex[changes[0][0]][0]];
-            c = c.concat(changes[0].slice(1, 1 + 3));
-            console.log("Brent Bugtesting - c at point 2: " + c);
-            console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
-            console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
-            console.log("Brent Bugtesting - type of c: " + typeof(c));
+          if (changes.length > 1){
+            for (i = 0; i < changes.length; i++){
+              if(c){
+                c[i] = [this.sortIndex[changes[i][0]][0]];
+                c[i] = c[i].concat(changes[i].slice(1, 1 + 3));
+              } else {
+                c = new Array ( );
+                c[i] = [this.sortIndex[changes[i][0]][0]];
+                c[i] = c[i].concat(changes[i].slice(1, 1 + 3));
+              }
+            }
           } else {
-            console.log("Second condition met.");
-            c = changes;
+            if (this.sortIndex && this.sortIndex.length !== 0) {
+              console.log("First condition met.");
+              console.log("changes length: " + changes.length);
+              c = [this.sortIndex[changes[0][0]][0], changes[0].slice(1, 1 + 3)];
+              console.log("Brent Bugtesting - c at point 1: " + c);
+              c = [this.sortIndex[changes[0][0]][0]];
+              c = c.concat(changes[0].slice(1, 1 + 3));
+              console.log("Brent Bugtesting - c at point 2: " + c);
+              console.log("Brent Bugtesting - sortIndex[changes]: " + this.sortIndex[changes]);
+              console.log("Brent Bugtesting - this.sortIndex: " + this.sortIndex);
+              console.log("Brent Bugtesting - type of c: " + typeof(c));
+            } else {
+              console.log("Second condition met.");
+              c = changes;
+            }
           }
         
           

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -111,14 +111,14 @@ HTMLWidgets.widget({
       if (HTMLWidgets.shinyMode) {
         if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
-            c = this.sortIndex[changes[0][0]][0];
+            c = [this.sortIndex[changes[0][0]][0]];
             console.log("c: " + c);
             console.log("sortIndex[changes]: " + this.sortIndex[changes]);
             console.log("this.sortIndex: " + this.sortIndex);
             console.log("type of c: " + typeof(c));
-            //c = c.concat(changes[0].slice(1, 1 + 3));
+            c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
-            //c = changes;
+            c = changes;
           }
           
           if (this.params && this.params.debug) {

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -111,7 +111,15 @@ HTMLWidgets.widget({
       if (HTMLWidgets.shinyMode) {
         if (changes && (changes[0][2] !== null || changes[0][3] !== null)) {
           if (changes.length > 1){
-            c = changes
+            if (this.sortIndex && this.sortIndex.length !== 0) {
+              c = new Array ();
+              for(i=0;i<changes.length;i++){
+                c[i] = [this.sortIndex[changes[i][0]][0]];
+                c[i] = c[i].concat(changes[i].slice(1, 1+3));
+              }
+            } else {
+              c = changes
+            }
           } else {
             if (this.sortIndex && this.sortIndex.length !== 0) {
               console.log("First condition met.");

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -112,8 +112,9 @@ HTMLWidgets.widget({
         if (changes && (changes[0][2] !== null || changes[0][3] !== null) && (changes[0][2] !== changes[0][3])) {
           if (this.sortIndex && this.sortIndex.length !== 0) {
             c = this.sortIndex[changes[0][0]][0];
-            console.log(c)
-            c = [c].concat(changes[0].slice(1, 1 + 3));
+            console.log(c);
+            console.log(this.sortIndex[changes]);
+            c = c.concat(changes[0].slice(1, 1 + 3));
           } else {
             c = changes;
           }


### PR DESCRIPTION
I've modified the afterChangeCallback function so that it will work more effectively with sorted columns, or at least be easier to parse. The prior code would return a set of two lists per change, one with the row number and one with everything else. If columns were sorted and multiple values were changed, then it would only return one copy of this list. The new code makes it so that changes to sorted columns are treated the same way as everything else (namely, that they would return a list of four items per change).