### PR TITLE
Fix issue with comment callback specifying incorrect ro

### DIFF
--- a/docs/libs/rhandsontable-0.3.5/rhandsontable.js
+++ b/docs/libs/rhandsontable-0.3.5/rhandsontable.js
@@ -171,12 +171,7 @@ HTMLWidgets.widget({
   afterCellMetaCallback: function(x) {
 
     x.afterSetCellMeta = function(r, c, key, val) {
-
       if (HTMLWidgets.shinyMode && key === "comment") {
-        if (this.sortIndex && this.sortIndex.length !== 0) {
-          r = this.sortIndex[r][0];
-        }
-
         if (this.params && this.params.debug) {
           if (this.params.debug > 0) {
             console.log("afterSetCellMeta: Shiny.onInputChange: " + this.rootElement.id);

--- a/docs/libs/rhandsontable-binding-0.3.4.5/rhandsontable.js
+++ b/docs/libs/rhandsontable-binding-0.3.4.5/rhandsontable.js
@@ -173,10 +173,6 @@ HTMLWidgets.widget({
     x.afterSetCellMeta = function(r, c, key, val) {
 
       if (HTMLWidgets.shinyMode && key === "comment") {
-        if (this.sortIndex && this.sortIndex.length !== 0) {
-          r = this.sortIndex[r][0];
-        }
-
         if (this.params && this.params.debug) {
           if (this.params.debug > 0) {
             console.log("afterSetCellMeta: Shiny.onInputChange: " + this.rootElement.id);

--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -173,10 +173,6 @@ HTMLWidgets.widget({
     x.afterSetCellMeta = function(r, c, key, val) {
 
       if (HTMLWidgets.shinyMode && key === "comment") {
-        if (this.sortIndex && this.sortIndex.length !== 0) {
-          r = this.sortIndex[r][0];
-        }
-
         if (this.params && this.params.debug) {
           if (this.params.debug > 0) {
             console.log("afterSetCellMeta: Shiny.onInputChange: " + this.rootElement.id);


### PR DESCRIPTION
I have had an issue where the comment callback on the Shiny side is not able to access the correct row that was clicked by the user, after the table has been sorted.

By deleting these few lines of code, `input$hot_comment$comment$r` will specify the unsorted row that was called, i.e. the correct row from `input$hot$data`. 