### PR TITLE
csvString export to other formats (analog write.csv2)

### DIFF
--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -321,21 +321,24 @@ function toArray(input) {
 }
 
 // csv logic adapted from https://github.com/juantascon/jquery-handsontable-csv
-function csvString(instance) {
+function csvString(instance,sep=",",dec=".") {
 
   var headers = instance.getColHeader();
 
-  var csv = headers.join(",") + "\n";
+  var csv = headers.join(sep) + "\n";
 
   for (var i = 0; i < instance.countRows(); i++) {
       var row = [];
       for (var h in headers) {
           var col = instance.propToCol(h);
           var value = instance.getDataAtRowProp(i, col);
+          if ( !isNaN(value) ) {
+            value = value.toString().replace(".",dec)
+          }
           row.push(value);
       }
 
-      csv += row.join(",");
+      csv += row.join(sep);
       csv += "\n";
   }
 


### PR DESCRIPTION
Added arguments sep and dec to the javascript function csvString.
This should enable csv export analog to the R write.csv2 function.

In particular, this is quite handy when coping with german csv files which are encoded with (sep=";" and dec=",").