### PR TITLE
correct iteration in hot_row

### DIFF
--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -519,7 +519,7 @@ hot_rows = function(hot, rowHeights = NULL, fixedRowsTop = NULL) {
 #' @seealso \code{\link{hot_cols}}, \code{\link{hot_cell}}
 #' @export
 hot_row = function(hot, row, readOnly = NULL) {
-  ct = hot$x$rDataDim[1]
+  ct = hot$x$rDataDim[2]
   for (i in seq_len(ct)) {
     if (!is.null(readOnly)) {
       hot =  hot %>% hot_cell(row, i, readOnly = readOnly)


### PR DESCRIPTION
the hot_row function should be iterating over the number of columns rather than the number of rows. currently, if there are more columns that rows, setting a row to readonly still results in some editable cells:
```
testdf <- data.frame(a=1:2,b=2:3,c=3:4)
tab <- rhandsontable(testdf)
tab <- hot_row(tab, 2, readOnly = TRUE)
tab
```