### PR TITLE
Update z-index for shiny modalDialogs

### DIFF
--- a/docs/libs/rhandsontable-0.3.7/rhandsontable.css
+++ b/docs/libs/rhandsontable-0.3.7/rhandsontable.css
@@ -18,7 +18,7 @@
 
 /* fix for shiny datepicker */
 .datepicker {
-  z-index: 1000 !important;
+  z-index: 9999 !important;
 }
 
 .handsontable table thead th {


### PR DESCRIPTION
It appears that when a `rhandsontable` object is used inside a `shiny` `modalDialog` with a `dateInput`/`dateRangeInput` widget, the configuration with `z-index: 1000` is not enough to show the datepicker.

That's why I suggest to substitute the `1000` with a `9999`.