### PR TITLE
Implement resize

### DIFF
--- a/inst/htmlwidgets/rhandsontable.js
+++ b/inst/htmlwidgets/rhandsontable.js
@@ -81,7 +81,11 @@ HTMLWidgets.widget({
   },
 
   resize: function(el, width, height, instance) {
-
+    if(instance)
+      instance.hot.updateSettings({
+        width: width,
+        height: height,
+      });
   },
 
   afterRender: function(x) {


### PR DESCRIPTION
Implement resize, fixes https://github.com/ramnathv/htmlwidgets/issues/161

```r
library(shiny)
library(rhandsontable)

ui <- shinyUI(fluidPage(
  sidebarLayout(
    sidebarPanel(
      checkboxInput("check", "Show Table", FALSE),
      conditionalPanel("input.check === true",
                       rHandsontableOutput("tbl"))
    ),
    mainPanel()
  )
))

server <- function(input, output) {
  output$tbl <- renderRHandsontable({
    rhandsontable(data.frame(col1 = LETTERS[1:10], col2 = 1:10))
  })
}

shinyApp(ui = ui, server = server)
```

Not sure why it was not implemented, there may be a valid reason I am missing.