### PR TITLE
Fix rhandsontable() to handle empty datasets when useTypes = FALSE

### DIFF
--- a/R/rhandsontable.R
+++ b/R/rhandsontable.R
@@ -67,12 +67,19 @@ rhandsontable <- function(data, colHeaders, rowHeaders, comments = NULL,
   }
 
   if (!useTypes) {
-    data = do.call(cbind, lapply(data, function(x) {
-      if (class(x) == "Date")
-        as.character(x, format = "%m/%d/%Y")
-      else
-        as.character(x)
-    }))
+    data = do.call(
+      "cbind",
+      structure(
+        lapply(seq_len(ncol(data)), function(x){
+          if(class(data[, x]) == "Date") {
+            as.character(data[, x], format = "%m/%d/%Y")
+          } else {
+            as.character(data[, x])
+          }
+        }),
+        names = colnames(data)
+      )
+    )
     data = as.matrix(data, rownames.force = TRUE)
     cols = NULL
   } else {


### PR DESCRIPTION
@jrowen, just adding a simple fix to `rhandsontable()` to ensure that it appropriately handles data that is empty (i.e. all NA values).  As this loop was originally written, when the data is empty individual values are returned within the `lapply` call instead of a vector per column as normally expected. To fix this, I have updated the `lapply` call to explicitly extract the individual columns to ensure that they are handled correctly. I originally picked up this issue through my DataEditR package [issue#34](https://github.com/DillonHammill/DataEditR/issues/34).